### PR TITLE
Fix args passing & Add dom arguments support  

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,22 @@ Usage
 -----
 
 ```javascript
-LukesLazyLoader.load('your', 'css', 'and', 'js', 'files').then(callback).then(anotherCallback);
+LukesLazyLoader.load(['your', 'css', 'and', 'js', 'files']).then(callback).then(anotherCallback);
 ```
 whenever you need it. If you need seperate callbacks for each file simply call
 
 ```javascript
 LukesLazyLoader.load('file1').then(callback1);
 LukesLazyLoader.load('file2').then(callback2);
-LukesLazyLoader.load('file3' 'file4').then(callback3);
+LukesLazyLoader.load(['file3', 'file4']).then(callback3);
+```
+
+Additional options can be provided by using a plain object instead of an url
+
+```javascript
+LukesLazyLoader.load({url: 'file1', type: 'css'}).then(callback1);
+LukesLazyLoader.load({url: 'file2', args: {async: true}}).then(callback2);
+LukesLazyLoader.load([{url: 'file3'}, 'file4']).then(callback3);
 ```
 
 Compatibility
@@ -76,7 +84,7 @@ Todo
 * [ ] Minification
 * [ ] Tests
 * [ ] Improve Demo
- 
+
 License
 -------
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,9 +8,12 @@
     <script src="../lazyloader.js"></script>
     <script>
 
-        var loader = LukesLazyLoader.load('http://localhost:8080/500-f00.css',
-            'http://localhost:8080/1500-javascript.js',
-            'http://localhost:8080/2500-00f.css');
+        var loader = LukesLazyLoader.load([
+          'http://localhost:8080/500-f00.css',
+          'http://localhost:8080/1500-javascript.js',
+          {url: 'http://localhost:8080/2500-00f.css'},
+          {url: 'http://localhost:8080/3500-ffff00.css', args: {titi: 'toto'}},
+        ]);
 
         loader.then(function () {
             console.log('all files have been loaded');


### PR DESCRIPTION
I originally did separate commits but I fckd up and I can't open two PRs anymore. sorry for this. 

This fixes #5

BREAKING CHANGE: Force the use of an array instead of infinite arguments
eg: 
```js
 LukesLazyLoader.load(['file1', 'file2'])
 ```
 instead of 
```js
 LukesLazyLoader.load('file1', 'file2')
```
It also bring support for advanced source input, it can now be:
- a string
- an object 
	```
	{
	    args: object[string, string] // args to pass to dom
	    url: string // url to use
		 type: string // 'css' or 'js', replace auto detection 
    }
    ```